### PR TITLE
fixed path in README, changed how hotkey is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The [freja editor](https://github.com/saikyun/freja).
 ## Setup
 
 0. Clone this repository somewhere and cd to the resulting directory
-1. Start freja with: `freja ./freja-jandent/indent.janet`
+1. Start freja with: `freja ./freja-jandent/jandent-format.janet`
 2. `Control+L` to load the file
 
 ## Example Usage

--- a/freja-jandent/jandent-format.janet
+++ b/freja-jandent/jandent-format.janet
@@ -18,6 +18,7 @@
   (gb/replace-content gb new-text)
   (gb/put-caret gb caret))
 
-(put-in dh/gb-binds
-        [:control :shift :f]
-        (comp dh/reset-blink jandent-format))
+(dh/set-key dh/gb-binds
+            [:control :shift :f]
+            (comp dh/reset-blink jandent-format))
+ 


### PR DESCRIPTION
The preferred way to set hotkeys is using `input/set-key`, but it seemed unnecessary to me that one should have to import `freja/input`, so now it is reexported in `freja/default-hotkeys`. This means you can just `dh/set-key`. The reason one wants to use `set-key` is that the order of modifiers is handled for you (when using `put-in` you must use the right order manually).